### PR TITLE
Make work on Opensuse (and probably Fedora as well)

### DIFF
--- a/unl0kr-ask-password.sh
+++ b/unl0kr-ask-password.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/bash
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+# Trying to hide poymouth for unl0kr
+# Can only hide plymouth if we wait long enough to show it
+# TODO: Find way to do this without sleeping
+sleep 5
 plymouth hide-splash 2>/dev/null
 
-ttymode=$(stty -g)
-stty -echo -icanon min 0 time 0
-
+# Searching for passwords for unl0kr
 for file in `ls /run/systemd/ask-password/ask.*`; do
   socket="$(cat "$file" | grep "Socket=" | cut -d= -f2)"
   /usr/bin/unl0kr | /lib/systemd/systemd-reply-password 1 "$socket"
 done
 
-stty "$ttymode"
-
+# Try to show Plymouth again after unl0kr
 plymouth show-splash 2>/dev/null
-

--- a/unl0kr-dracut-module-setup.sh
+++ b/unl0kr-dracut-module-setup.sh
@@ -7,6 +7,7 @@ check() {
     return 255
 }
 
+# called by dracut
 depends() {
     return 0
 }
@@ -21,13 +22,23 @@ install() {
          /etc/unl0kr.conf.d/* \
          /lib/udev/rules.d/* \
          /etc/udev/rules.d/* \
-         /usr/share/libinput/*.quirks \
-         /usr/share/X11/xkb/* \
+         /etc/libinput/* \
+         /etc/xkb/* \
          /bin/unl0kr \
          /bin/udevadm \
+         /bin/grep \
          cut
+
+    for file in $(find /usr/share/libinput* -name '*.quirks'; find /usr/share/X11/xkb); do
+      inst "$file"
+    done
+
     inst_simple "$moddir/unl0kr-ask-password.sh" /usr/bin/unl0kr-ask-password
 
+    # Enable the systemd service unit for unl0kr-ask-password.
+    $SYSTEMCTL -q --root "$initdir" add-wants unl0kr-ask-password.service systemd-vconsole-setup.service
+
+    # Disable conflicting services
     $SYSTEMCTL -q --root "$initdir" mask systemd-ask-password-console.service || :
     $SYSTEMCTL -q --root "$initdir" mask systemd-ask-password-plymouth.service || :
     $SYSTEMCTL -q --root "$initdir" mask systemd-ask-password-console.path || :

--- a/unl0kr.conf
+++ b/unl0kr.conf
@@ -1,6 +1,6 @@
 [general]
 animations=true
-backend=drm
+backend=fbdev
 timeout=300
 
 [keyboard]


### PR DESCRIPTION
Summary of changes:
* Make the service wanted by vconsole otherwise it wouldn't actually be enabled.
* Add missing xkb and libinput files to dracut, otherwise unl0kr will send errors to stdout
* Use fbdev instead of drm as backend